### PR TITLE
Add David project card to Projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,25 @@ title: "Home"
                         <a href="https://drive.google.com/file/d/1npLudNQBb09_m_AR_Rq6GgmhCyfMGtTr/view" class="text-accent-color hover:text-accent-light font-medium inline-flex items-center">View Details &rarr;</a>
                     </div>
                 </div>
+                <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden transform transition duration-300 hover:scale-105">
+                    <a href="https://github.com/isaachuahy/david" class="block">
+                    <img src="https://placehold.co/600x400/111827/5eead4?text=David+Executive+AI+Assistant" alt="David Executive AI Assistant" class="w-full h-48 object-cover" onerror="this.src='https://placehold.co/600x400/1f2937/9ca3af?text=Image+Error'">
+                    </a>
+                    <div class="p-6">
+                        <a href="https://github.com/isaachuahy/david" class="text-xl font-semibold mb-2 block hover:text-accent-light transition duration-200">David: Executive AI Assistant</a>
+                        <p class="text-gray-400 text-sm mb-4">Built an operational personal AI assistant that connects conversational planning with real execution across time. David keeps context grounded in goals, weekly state and decision logs, while injecting live Google Calendar context to make practical scheduling suggestions.
+                            Uses explicit approval flows before any calendar write, supports session-aware memory, and automates recurring check-ins to reduce decision fatigue and keep priorities aligned week over week.
+                        </p>
+                         <div class="flex flex-wrap gap-2 mb-4">
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Python</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Telegram Bot</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Gemini</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">SQLite</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Google Calendar API</span>
+                        </div>
+                        <a href="https://github.com/isaachuahy/david" class="text-accent-color hover:text-accent-light font-medium inline-flex items-center">View Details &rarr;</a>
+                    </div>
+                </div>
                  <!-- <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden transform transition duration-300 hover:scale-105">
                     <img src="https://placehold.co/600x400/1f2937/9ca3af?text=Project+3+Image" alt="Project 3 Placeholder" class="w-full h-48 object-cover" onerror="this.src='https://placehold.co/600x400/1f2937/9ca3af?text=Image+Error'">
                     <div class="p-6">


### PR DESCRIPTION
### Motivation
- Surface the `David` project in the portfolio so the Projects section reflects recent work and maintains consistent presentation across entries.

### Description
- Updated `index.html` to insert a new project card for "David: Executive AI Assistant" inside the Projects grid.
- The card follows existing layout and styles (same `bg-gray-800`, rounded card, image fallback via `onerror`, hover scale, typography and CTA pattern) and links the image, title, and CTA to `https://github.com/isaachuahy/david`.
- Included a concise project summary and matching tech tags (`Python`, `Telegram Bot`, `Gemini`, `SQLite`, `Google Calendar API`) to match the portfolio's writing style and tag design.

### Testing
- No automated tests are configured for this static site.
- Locally validated the new card's HTML structure and attributes in `index.html`; markup and link targets are correct and visual structure matches existing project cards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9fb7ee0c8324afd64816b7b5ceb2)