### PR TITLE
Add "David: Executive AI Assistant" project card to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,25 @@ title: "Home"
             <div class="w-20 h-1 bg-accent-color mx-auto mb-12 rounded"></div>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-10">
                 <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden transform transition duration-300 hover:scale-105">
+                    <a href="https://github.com/isaachuahy/david" class="block">
+                    <img src="https://images.pexels.com/photos/3861969/pexels-photo-3861969.jpeg?auto=compress&cs=tinysrgb&w=1200" alt="David Executive AI Assistant" class="w-full h-48 object-cover" onerror="this.src='https://placehold.co/600x400/1f2937/9ca3af?text=Image+Error'">
+                    </a>
+                    <div class="p-6">
+                        <a href="https://github.com/isaachuahy/david" class="text-xl font-semibold mb-2 block hover:text-accent-light transition duration-200">David: Executive AI Assistant</a>
+                        <p class="text-gray-400 text-sm mb-4">Built an operational personal AI assistant that connects conversational planning with real execution across time. David keeps context grounded in goals, weekly state and decision logs, while injecting live Google Calendar context to make practical scheduling suggestions.
+                            Uses explicit approval flows before any calendar write, supports session-aware memory, and automates recurring check-ins to reduce decision fatigue and keep priorities aligned week over week.
+                        </p>
+                         <div class="flex flex-wrap gap-2 mb-4">
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Python</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Telegram Bot</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Gemini</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">SQLite</span>
+                            <span class="bg-gray-700 text-teal-300 text-xs font-semibold px-2.5 py-0.5 rounded">Google Calendar API</span>
+                        </div>
+                        <a href="https://github.com/isaachuahy/david" class="text-accent-color hover:text-accent-light font-medium inline-flex items-center">View Details &rarr;</a>
+                    </div>
+                </div>
+                <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden transform transition duration-300 hover:scale-105">
                     <a href="https://github.com/isaachuahy/ml-monitor" class="block">
                     <img src="images/MLMonitorDashboard.png" alt="ML Model Monitoring System" class="w-full h-48 object-cover">
                     </a>


### PR DESCRIPTION
### Motivation
- Add a new project entry to the Projects section to showcase the "David: Executive AI Assistant" repository and its capabilities.

### Description
- Insert a new project card markup into `index.html` inside the projects grid that includes an image with an `onerror` fallback, title and description text, technology tag badges, and links to the GitHub repository with hover/transition styling.

### Testing
- Ran HTML validation of `index.html` against an automated validator which reported no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9fb7ee0c8324afd64816b7b5ceb2)